### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -3,7 +3,7 @@ name: Feature actions
 on:
   push:
     branches-ignore:
-      - 'main'
+      - "main"
 
 jobs:
   install-packages:
@@ -47,7 +47,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: audit
+    needs:
+      - lint-typescript
+      - lint-docker
     container: exilesprx/blockchain:source
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +62,7 @@ jobs:
 
       - name: Test code
         run: pnpm run test
-  
+
   typescript-build-bank:
     runs-on: ubuntu-latest
     needs: test
@@ -92,3 +94,4 @@ jobs:
 
       - name: Build
         run: pnpm run build:miner
+


### PR DESCRIPTION
Let the builds run regardless of audits in the event two vulnerabilities occur in which case, the first will always fail. So make sure the builds pass so all the vulnerability changes can be merged.