### PR TITLE
Continue on error

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Audit packages
+        continue-on-error: true
         run: docker compose -f docker-compose.build.yml run -v $PWD:/usr/app main sh -c "pnpm audit"
 
   test:


### PR DESCRIPTION
Allow the audit step to be optional. Sometimes a vulnerability cannot be addresses until a later time.